### PR TITLE
Adds GEOEMTRY_STATUS_SYMBOL_COLOR_HASH_COLORS

### DIFF
--- a/functions/geometry_status.zsh
+++ b/functions/geometry_status.zsh
@@ -13,9 +13,17 @@ geometry_status() {
 
     (($(echotc Co) == 256)) && colors+=({17..230})
 
+    if (( ${+GEOMETRY_STATUS_SYMBOL_COLOR_HASH_COLORS} )); then
+      colors=(${GEOMETRY_STATUS_SYMBOL_COLOR_HASH_COLORS})
+    fi
+
     local sum=0; for c in ${(s::)^HOST}; do ((sum += $(print -f '%d' "'$c"))); done
 
-    GEOMETRY_STATUS_COLOR=${colors[$(($sum % ${#colors}))]}
+    local index=$(($sum % ${#colors})) 
+
+    [[ "$index" -eq 0 ]] && index=1
+
+    GEOMETRY_STATUS_COLOR=${colors[${index}]}
   }
 
   local color=GEOMETRY_STATUS_COLOR symbol=GEOMETRY_STATUS_SYMBOL


### PR DESCRIPTION
I spent some time looking at how we come up with the colors that we'll show when the `GEOMETRY_STATUS_SYMBOL_COLOR_HASH` variable is set. And one thing I noticed in my situation was that I was getting a really dark color that blended with my background.

So, let's give the user the option to pass what colors the user can pick.

```
GEOMETRY_STATUS_SYMBOL_COLOR_HASH_COLORS=({2..7} {10..14} {172..177} {190..195} {226..229})
```

The above should overrule what is currently set in the `local colors` variable.

Also, please note that the expression below can return 0 sometimes and that will cause a silent error. It'll just not show a symbol at all. Hence the extra check added.

```
$(($sum % ${#colors}))
```

---

I'm not entirely sure if this implementation is up to your code standards. So I leave it here for your consideration. 